### PR TITLE
Add shebang line to scripts

### DIFF
--- a/build-libuv.sh
+++ b/build-libuv.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 cd libuv
 sh autogen.sh
 ./configure

--- a/buildall.sh
+++ b/buildall.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 usage()
 {
     echo "builds a bootstrap CLI from sources"


### PR DESCRIPTION
Using `/usr/bin/env bash` here because `bash` is not always located in `/usr/bin`.
