### PR TITLE
use uname to get cpu/ostype instead of hardcoding

### DIFF
--- a/buildall.sh
+++ b/buildall.sh
@@ -4,8 +4,8 @@ usage()
     echo "builds a bootstrap CLI from sources"
 }
 
-__build_arch=x64
-__build_os=Linux
+__build_arch=$(uname -p)
+__build_os=$(uname -s)
 __runtime_id=
 __corelib=
 __coreclrbin=


### PR DESCRIPTION
I'm using freebsd so this should make porting a little easier. It does not yet compile but this should help.

Freebsd reports : amd64/FreeBSD
OSX reports : i386/Darwin (technically correct since it runs a 32 bit kernel :( )
